### PR TITLE
projectiles damaging traps

### DIFF
--- a/src/MapManager.ts
+++ b/src/MapManager.ts
@@ -16,7 +16,7 @@ import { collidableComponent } from './entity/components/Collidable';
 import { createTileset } from './renderer/createTileset';
 import { renderableComponent } from './entity/components/Renderable';
 import { sizeComponent } from './entity/components/Size';
-import { enemies, type Enemies } from './entity/components/Enemy';
+import { EnemyType } from './entity/components/Enemy';
 import { createTrap } from './entity/factories/createTrap';
 import type { ECSEntity } from './ecs/ECSEntity';
 import { hasAnimatable } from './entity/components/Animatable';
@@ -28,10 +28,8 @@ export type TMap = {
   level: number;
 };
 
-const enemiesOnLevel: Record<Enemies, number>[] = [{ trap: 1 }, { trap: 2 }];
-
-const spawners: Record<Enemies, (world: ECSWorld) => ECSEntity> = {
-  trap: (world: ECSWorld) => createTrap(world, { enemy: codex.enemies.trap })
+const spawners: Record<EnemyType, (world: ECSWorld) => ECSEntity> = {
+  trap: (world: ECSWorld) => createTrap(world, { enemy: codex.enemies.trap() })
 };
 
 export const maps = [
@@ -297,13 +295,14 @@ export async function loadMap(
   player.position.x = spawnLocation?.x;
   player.position.y = spawnLocation?.y;
 
-  for (const enemyKey of enemies) {
+  for (const enemyKey of Object.values(EnemyType)) {
     const amount = rng.nextRange(3, 5) + map.level * 2;
     for (let i = 0; i < amount; i++) {
       const randomIndex = Math.floor(rng.nextF() * enemySpawnLocations.length);
       const location = enemySpawnLocations[randomIndex]!;
       enemySpawnLocations.splice(randomIndex, 1);
-      const enemy = spawners[enemyKey](world);
+      const spawner = spawners[enemyKey]!;
+      const enemy = spawner(world);
       if (hasPosition(enemy)) {
         enemy.position.x = location.x;
         enemy.position.y = location.y;

--- a/src/assets/codex/classes/index.ts
+++ b/src/assets/codex/classes/index.ts
@@ -3,4 +3,4 @@ import { wizard } from './wizard';
 
 export const playerClasses = {
   wizard
-} satisfies Record<string, CodexPlayerClass>;
+} satisfies Record<string, () => CodexPlayerClass>;

--- a/src/assets/codex/classes/wizard.ts
+++ b/src/assets/codex/classes/wizard.ts
@@ -1,9 +1,9 @@
 import type { CodexPlayerClass } from '@/assets/types';
 
-export const wizard: CodexPlayerClass = {
+export const wizard = (): CodexPlayerClass => ({
   spriteName: 'wizard',
   baseStats: {
     speed: 3,
     health: 10
   }
-};
+});

--- a/src/assets/codex/enemies/index.ts
+++ b/src/assets/codex/enemies/index.ts
@@ -3,4 +3,4 @@ import { trap } from './trap';
 
 export const enemies = {
   trap
-} satisfies Record<string, CodexEnemy>;
+} satisfies Record<string, () => CodexEnemy>;

--- a/src/assets/codex/enemies/trap.ts
+++ b/src/assets/codex/enemies/trap.ts
@@ -1,9 +1,9 @@
 import type { CodexEnemy } from '@/assets/types';
 
-export const trap: CodexEnemy = {
+export const trap = (): CodexEnemy => ({
   spriteName: 'trap',
   baseStats: {
     speed: 0,
     health: 4
   }
-};
+});

--- a/src/assets/codex/projectiles/index.ts
+++ b/src/assets/codex/projectiles/index.ts
@@ -3,4 +3,4 @@ import { magicMissile } from './magic-missile';
 
 export const projectiles = {
   magicMissile
-} satisfies Record<string, CodexProjectile>;
+} satisfies Record<string, () => CodexProjectile>;

--- a/src/assets/codex/projectiles/magic-missile.ts
+++ b/src/assets/codex/projectiles/magic-missile.ts
@@ -1,9 +1,9 @@
 import type { CodexProjectile } from '@/assets/types';
 
-export const magicMissile: CodexProjectile = {
+export const magicMissile = (): CodexProjectile => ({
   spriteName: 'magicMissile',
   baseStats: {
     speed: 3,
     power: 1
   }
-};
+});

--- a/src/createGameLoop.ts
+++ b/src/createGameLoop.ts
@@ -34,9 +34,10 @@ import { loadSpriteTextures } from './renderer/createAnimatedSprite';
 import { EnemySystem } from './systems/EnemySystem';
 import type { ECSEntityId } from './ecs/ECSEntity';
 import { damageHandler } from './eventHandlers/damageHandler';
-import { playerClasses } from './assets/codex/classes';
 import { simpleMapGen } from '@/map/Map';
 import { lehmerRandom } from '@/utils/rand/random';
+import { ProjectileSystem } from './systems/ProjectileSystem';
+import { codex } from './assets/codex';
 
 // @TODO maybe we should externalize all the queue related code to its own file...we might end up with a lot of different events
 export const EventNames = {
@@ -154,7 +155,9 @@ const setup = async (app: Application, world: ECSWorld) => {
   // another possible fix would be to place the player on the map spawn point somewhere else, removing the dependency to the player
   // The whole map loading process will probably be completely revamped fairly soon, so no need to overthink it for now, just to parallel load some things
   await loadSpriteTextures();
-  const player = createPlayer(world, { playerClass: playerClasses.wizard });
+  const player = createPlayer(world, {
+    playerClass: codex.playerClasses.wizard()
+  });
   await loadMap(map, true, app, world);
 
   const camera = createCamera(world, player.entity_id);
@@ -174,6 +177,7 @@ export function createGameLoop(
   );
   const controls = createControls(renderer.app, queue);
 
+  world.addSystem('projectile', ProjectileSystem());
   world.addSystem('movement', MovementSystem());
   world.addSystem('render', RenderSystem(resolveRenderable, renderer.app));
   world.addSystem('debug_renderer', DebugRenderer(renderer.app));

--- a/src/entity/components/Enemy.ts
+++ b/src/entity/components/Enemy.ts
@@ -1,21 +1,23 @@
 import type { ECSComponent } from '@/ecs/ECSComponent';
 import { ecsComponent, has } from '@/ecs/ECSComponent';
-import type { Stats } from '@/utils/types';
+import type { Stats, Values } from '@/utils/types';
 
 export type EnemyStats = {
   speed: number;
   health: number;
 };
 
-export const enemies = ['trap'] as const;
-export type Enemies = typeof enemies[number];
+export const EnemyType = {
+  TRAP: 'trap'
+};
+export type EnemyType = Values<typeof EnemyType>;
 
 export const EnemyBrand = 'enemy';
 type EnemyBrand = typeof EnemyBrand;
 export type Enemy = ECSComponent<
   EnemyBrand,
   {
-    type: Enemies;
+    type: EnemyType;
     stats: Stats<EnemyStats>;
   }
 >;

--- a/src/entity/factories/createPlayer.ts
+++ b/src/entity/factories/createPlayer.ts
@@ -13,6 +13,7 @@ import { registerStateMachine } from '../../stateMachines/stateMachineManager';
 import { createPlayerStateMachine } from '../../stateMachines/player';
 import { sizeComponent } from '../components/Size';
 import type { CodexPlayerClass } from '@/assets/types';
+import { collidableComponent } from '../components/Collidable';
 
 export type CreatePlayerOptions = {
   playerClass: CodexPlayerClass;

--- a/src/entity/factories/createTrap.ts
+++ b/src/entity/factories/createTrap.ts
@@ -12,6 +12,7 @@ import { enemyComponent } from '../components/Enemy';
 import { registerStateMachine } from '@/stateMachines/stateMachineManager';
 import { createTrapStateMachine } from '@/stateMachines/trap';
 import type { CodexEnemy } from '@/assets/types';
+import { collidableComponent } from '../components/Collidable';
 
 export type CreateTrapOptions = {
   enemy: CodexEnemy;

--- a/src/eventHandlers/playerAttack.ts
+++ b/src/eventHandlers/playerAttack.ts
@@ -34,7 +34,7 @@ export const playerAttackHandler = (mousePosition: Point, world: ECSWorld) => {
 
   createProjectile(world, {
     firedBy: player.entity_id,
-    projectile: codex.projectiles.magicMissile,
+    projectile: codex.projectiles.magicMissile(),
     position: { ...player.position },
     target: subVector(mousePosition, sprite.toGlobal({ x: 0, y: 0 }))
   });

--- a/src/eventHandlers/playerDamagedHandler.ts
+++ b/src/eventHandlers/playerDamagedHandler.ts
@@ -8,9 +8,7 @@ import {
   RenderableBrand,
   type Renderable
 } from '@/entity/components/Renderable';
-import { PlayerStateTransitions } from '@/stateMachines/player';
-import { resolveStateMachine } from '@/stateMachines/stateMachineManager';
-import { clamp } from '@/utils/math';
+import { dealDamage } from '@/utils/ecsUtils';
 
 export const playerDamagedHandler = (
   damage: number,
@@ -24,17 +22,14 @@ export const playerDamagedHandler = (
   ]);
   if (!player) return;
 
-  player.player.stats.current.health = clamp(
-    player.player.stats.current.health - damage,
-    0,
-    player.player.stats.base.health
-  );
-
-  const machine = resolveStateMachine(player.entity_id);
-  machine.send(PlayerStateTransitions.TAKE_DAMAGE);
+  dealDamage({
+    to: player,
+    amount: damage,
+    ecs: world
+  });
 
   if (player.player.stats.current.health <= 0) {
-    // alert('you dead');
-    // navigateTo('/');
+    alert('you dead');
+    navigateTo('/');
   }
 };

--- a/src/fx/player.ts
+++ b/src/fx/player.ts
@@ -3,6 +3,7 @@ import type { PlayerEntity } from '@/entity/factories/createPlayer';
 import type { ECSWorld } from '@/ecs/ECSWorld';
 import { resolveRenderable } from '@/renderer/renderableManager';
 import type { AnimatedSprite } from 'pixi.js';
+import type { TrapEntity } from '@/entity/factories/createTrap';
 
 export const playerHitFX = (entity: PlayerEntity, world: ECSWorld) => {
   world.get<TAudioManager>('audio').match(

--- a/src/fx/trap.ts
+++ b/src/fx/trap.ts
@@ -1,0 +1,13 @@
+import type { TrapEntity } from '@/entity/factories/createTrap';
+import { resolveRenderable } from '@/renderer/renderableManager';
+import type { AnimatedSprite } from 'pixi.js';
+
+export const trapHitFX = (entity: TrapEntity) => {
+  const sprite = resolveRenderable<AnimatedSprite>(entity.entity_id);
+  sprite.tint = 0xff0000;
+};
+
+export const trapHitEndFX = (entity: TrapEntity) => {
+  const sprite = resolveRenderable<AnimatedSprite>(entity.entity_id);
+  sprite.tint = 0xffffff;
+};

--- a/src/stateMachines/projectile.ts
+++ b/src/stateMachines/projectile.ts
@@ -27,7 +27,7 @@ export const createProjectileStateMachine = (
   world: ECSWorld
 ) => {
   const machine = createMachine({
-    id: `trap-${entity.entity_id}`,
+    id: `projectile-${entity.entity_id}`,
     initial: 'idle',
     predictableActionArguments: true,
     states: {

--- a/src/stateMachines/trap.ts
+++ b/src/stateMachines/trap.ts
@@ -6,12 +6,15 @@ import { AnimationState } from '@/entity/components/Animatable';
 import { getAnimationDuration } from '@/renderer/renderableUtils';
 import { resolveRenderable } from '@/renderer/renderableManager';
 import type { Sprite } from 'pixi.js';
+import { trapHitEndFX, trapHitFX } from '@/fx/trap';
+import type { ECSWorld } from '@/ecs/ECSWorld';
 
 export const TrapState = {
   IDLE: 'idle',
   TRIGGERED: 'triggered',
   ACTIVATING: 'activating',
   READY: 'ready',
+  HIT: 'hit',
   COOL_DOWN: 'coolDown'
 } as const;
 export type TrapState = Values<typeof TrapState>;
@@ -24,6 +27,7 @@ export type TrapReadyState = Values<typeof TrapReadyState>;
 
 export const TrapStateTransitions = {
   TRIGGER: 'trigger',
+  TAKE_DAMAGE: 'take damage',
   REACHED_PLAYER: 'reached_player'
 } as const;
 export type TrapStateTransitions = Values<typeof TrapStateTransitions>;
@@ -91,10 +95,26 @@ export const createTrapStateMachine = (entity: TrapEntity) => {
               state: AnimationState.IDLE
             });
           }
+        },
+        [TrapState.HIT]: {
+          entry() {
+            trapHitFX(entity);
+          },
+
+          exit() {
+            trapHitEndFX(entity);
+          },
+
+          after: {
+            HIT_DELAY: {
+              target: TrapState.IDLE
+            }
+          }
         }
       },
       on: {
-        [TrapStateTransitions.REACHED_PLAYER]: TrapState.COOL_DOWN
+        [TrapStateTransitions.REACHED_PLAYER]: TrapState.COOL_DOWN,
+        [TrapStateTransitions.TAKE_DAMAGE]: TrapState.HIT
       }
     },
     {
@@ -109,7 +129,8 @@ export const createTrapStateMachine = (entity: TrapEntity) => {
             entity.animatable.spriteName,
             AnimationState.READY
           ),
-        ATTACK_COOLDOWN: () => 1000
+        ATTACK_COOLDOWN: () => 1000,
+        HIT_DELAY: () => 250
       }
     }
   );

--- a/src/systems/MovementSystem.ts
+++ b/src/systems/MovementSystem.ts
@@ -41,6 +41,7 @@ import {
   ProjectileState,
   ProjectileStateTransitions
 } from '@/stateMachines/projectile';
+import { removeProjectile } from '@/utils/ecsUtils';
 
 export const MovementSystem: () => ECSSystem<
   [Position, Velocity, Orientation, Size, StateAware, Animatable]
@@ -77,11 +78,10 @@ export const MovementSystem: () => ECSSystem<
         });
 
       const onProjectileCollision = () => {
+        if (!hasProjectile(e)) return;
         if (machine.getSnapshot().value === ProjectileState.DEAD) return;
         machine.send(ProjectileStateTransitions.DIE);
-        setTimeout(() => {
-          world.addComponent(e.entity_id, deleteComponent);
-        }, getAnimationDuration(e.animatable.spriteName, AnimationState.DEAD));
+        removeProjectile(e, world);
       };
 
       // snap back position to closest safe spot, to avoid getting stuck in a wall

--- a/src/systems/MovementSystem.ts
+++ b/src/systems/MovementSystem.ts
@@ -56,39 +56,17 @@ export const MovementSystem: () => ECSSystem<
       [CollidableBrand, SizeBrand, PositionBrand]
     );
 
-    entities.forEach(e => {
-      if (hasImmoveable(e)) {
-        return;
-      }
-      const machine = resolveStateMachine(e.entity_id);
+    const getHitbox = (e: typeof entities[number]) =>
+      getSpriteHitbox({
+        entity: e,
+        hitboxId: HitBoxId.BODY_COLLISION,
+        animationState: getAnimationState(e.entity_id)!
+      });
 
-      if (hasPlayer(e) && machine.getSnapshot().value !== PlayerState.RUNNING)
-        return;
-      if (hasProjectile(e) && machine.getSnapshot().value !== PlayerState.IDLE)
-        return;
-
-      const getHitbox = () =>
-        getSpriteHitbox({
-          entity: e,
-          hitboxId: HitBoxId.BODY_COLLISION,
-          animationState: getAnimationState(e.entity_id)!
-        });
-
-      const onProjectileCollision = () => {
-        if (!hasProjectile(e)) return;
-        if (machine.getSnapshot().value === ProjectileState.DEAD) return;
-        removeProjectile(e, world);
-      };
-
-      // snap back position to closest safe spot, to avoid getting stuck in a wall
-      // this involves getting the potential overlaps with a collidable, in all 4 directions
-      // then applying the minimal corrections possible to fix potential issues
-      // there are a few cases this doesnt covers for now
-      // - correcting in both the horizontal and vertical axis: potentially we could get stuck in a corner ? I guess fixing one direction should be enough
-      // - having a large sprite going completely through a collidable: the directionAware collision check does not cover it because skill issue on my part è_é
+    const handleSnapback = (e: typeof entities[number]) => {
       for (const collidable of collidables) {
         const { left, right, up, down } = directionAwareRectRectCollision(
-          getHitbox(),
+          getHitbox(e),
           entityToRect(collidable)
         );
         const horizontalCorrection = left > right ? -left : right;
@@ -101,32 +79,60 @@ export const MovementSystem: () => ECSSystem<
           e.position.y += verticalCorrection;
         }
       }
+    };
+
+    const handleProjectileMovement = (e: typeof entities[number]) => {
+      if (!hasProjectile(e)) return;
+
+      const machine = resolveStateMachine(e.entity_id);
+      const state = machine.getSnapshot().value;
+
+      if (state !== ProjectileState.IDLE) return;
+
+      e.position = addVector(e.position, {
+        x: e.velocity.x,
+        y: e.velocity.y
+      });
+      for (const collidable of collidables) {
+        if (rectRectCollision(entityToRect(collidable), getHitbox(e))) {
+          if (machine.getSnapshot().value === ProjectileState.DEAD) return;
+          removeProjectile(e, world);
+          break;
+        }
+      }
+    };
+
+    const handlePlayerMovement = (e: typeof entities[number]) => {
+      if (!hasPlayer(e)) return;
+
+      const machine = resolveStateMachine(e.entity_id);
+      const state = machine.getSnapshot().value;
+      if (state !== PlayerState.RUNNING) return;
 
       e.position = addVector(e.position, { x: e.velocity.x, y: 0 });
       for (const collidable of collidables) {
-        if (rectRectCollision(entityToRect(collidable), getHitbox())) {
-          if (hasPlayer(e)) {
-            e.position = subVector(e.position, { x: e.velocity.x, y: 0 });
-          }
-          if (hasProjectile(e)) {
-            return onProjectileCollision();
-          }
+        if (rectRectCollision(entityToRect(collidable), getHitbox(e))) {
+          e.position = subVector(e.position, { x: e.velocity.x, y: 0 });
           break;
         }
       }
 
       e.position = addVector(e.position, { x: 0, y: e.velocity.y });
       for (const collidable of collidables) {
-        if (rectRectCollision(entityToRect(collidable), getHitbox())) {
-          if (hasPlayer(e)) {
-            e.position = subVector(e.position, { x: 0, y: e.velocity.y });
-          }
-          if (hasProjectile(e)) {
-            return onProjectileCollision();
-          }
-          break;
+        if (rectRectCollision(entityToRect(collidable), getHitbox(e))) {
+          e.position = subVector(e.position, { x: 0, y: e.velocity.y });
         }
       }
+    };
+
+    entities.forEach(e => {
+      if (hasImmoveable(e)) {
+        return;
+      }
+
+      handleSnapback(e);
+      handlePlayerMovement(e);
+      handleProjectileMovement(e);
     });
   }
 });

--- a/src/systems/MovementSystem.ts
+++ b/src/systems/MovementSystem.ts
@@ -1,7 +1,6 @@
 import type { ECSSystem } from '@/ecs/ECSSystem';
 import {
   AnimatableBrand,
-  AnimationState,
   type Animatable
 } from '@/entity/components/Animatable';
 import {
@@ -19,7 +18,6 @@ import { VelocityBrand, type Velocity } from '@/entity/components/Velocity';
 import { getAnimationState } from '@/renderer/AnimationManager';
 import {
   entityToRect,
-  getAnimationDuration,
   getSpriteHitbox,
   HitBoxId
 } from '@/renderer/renderableUtils';
@@ -32,7 +30,6 @@ import { resolveStateMachine } from '@/stateMachines/stateMachineManager';
 import { PlayerState } from '@/stateMachines/player';
 import { hasPlayer } from '@/entity/components/Player';
 import { hasProjectile } from '@/entity/components/Projectile';
-import { deleteComponent } from '@/entity/components/Delete';
 import {
   StateAwareBrand,
   type StateAware
@@ -80,7 +77,6 @@ export const MovementSystem: () => ECSSystem<
       const onProjectileCollision = () => {
         if (!hasProjectile(e)) return;
         if (machine.getSnapshot().value === ProjectileState.DEAD) return;
-        machine.send(ProjectileStateTransitions.DIE);
         removeProjectile(e, world);
       };
 
@@ -113,7 +109,7 @@ export const MovementSystem: () => ECSSystem<
             e.position = subVector(e.position, { x: e.velocity.x, y: 0 });
           }
           if (hasProjectile(e)) {
-            onProjectileCollision();
+            return onProjectileCollision();
           }
           break;
         }
@@ -126,7 +122,7 @@ export const MovementSystem: () => ECSSystem<
             e.position = subVector(e.position, { x: 0, y: e.velocity.y });
           }
           if (hasProjectile(e)) {
-            onProjectileCollision();
+            return onProjectileCollision();
           }
           break;
         }

--- a/src/systems/MovementSystem.ts
+++ b/src/systems/MovementSystem.ts
@@ -56,39 +56,17 @@ export const MovementSystem: () => ECSSystem<
       [CollidableBrand, SizeBrand, PositionBrand]
     );
 
-    entities.forEach(e => {
-      if (hasImmoveable(e)) {
-        return;
-      }
-      const machine = resolveStateMachine(e.entity_id);
+    const getHitbox = (e: typeof entities[number]) =>
+      getSpriteHitbox({
+        entity: e,
+        hitboxId: HitBoxId.BODY_COLLISION,
+        animationState: getAnimationState(e.entity_id)!
+      });
 
-      if (hasPlayer(e) && machine.getSnapshot().value !== PlayerState.RUNNING)
-        return;
-      if (hasProjectile(e) && machine.getSnapshot().value !== PlayerState.IDLE)
-        return;
-
-      const getHitbox = () =>
-        getSpriteHitbox({
-          entity: e,
-          hitboxId: HitBoxId.BODY_COLLISION,
-          animationState: getAnimationState(e.entity_id)!
-        });
-
-      const onProjectileCollision = () => {
-        if (!hasProjectile(e)) return;
-        if (machine.getSnapshot().value === ProjectileState.DEAD) return;
-        removeProjectile(e, world);
-      };
-
-      // snap back position to closest safe spot, to avoid getting stuck in a wall
-      // this involves getting the potential overlaps with a collidable, in all 4 directions
-      // then applying the minimal corrections possible to fix potential issues
-      // there are a few cases this doesnt covers for now
-      // - correcting in both the horizontal and vertical axis: potentially we could get stuck in a corner ? I guess fixing one direction should be enough
-      // - having a large sprite going completely through a collidable: the directionAware collision check does not cover it because skill issue on my part è_é
+    const handleSnapback = (e: typeof entities[number]) => {
       for (const collidable of collidables) {
         const { left, right, up, down } = directionAwareRectRectCollision(
-          getHitbox(),
+          getHitbox(e),
           entityToRect(collidable)
         );
         const horizontalCorrection = left > right ? -left : right;
@@ -101,32 +79,60 @@ export const MovementSystem: () => ECSSystem<
           e.position.y += verticalCorrection;
         }
       }
+    };
+
+    const handleProjectileMovement = (e: typeof entities[number]) => {
+      if (!hasProjectile(e)) return;
+
+      const machine = resolveStateMachine(e.entity_id);
+      const state = machine.getSnapshot().value;
+
+      if (state !== ProjectileState.IDLE) return;
+
+      e.position = addVector(e.position, {
+        x: e.velocity.x,
+        y: e.velocity.y
+      });
+      for (const collidable of collidables) {
+        if (rectRectCollision(entityToRect(collidable), getHitbox(e))) {
+          if (machine.getSnapshot().value === ProjectileState.DEAD) return;
+          removeProjectile(e, world);
+          break;
+        }
+      }
+    };
+
+    const handlePlayerMovement = (e: typeof entities[number]) => {
+      if (hasPlayer(e)) return;
+
+      const machine = resolveStateMachine(e.entity_id);
+      const state = machine.getSnapshot().value;
+      if (state !== PlayerState.RUNNING) return;
 
       e.position = addVector(e.position, { x: e.velocity.x, y: 0 });
       for (const collidable of collidables) {
-        if (rectRectCollision(entityToRect(collidable), getHitbox())) {
-          if (hasPlayer(e)) {
-            e.position = subVector(e.position, { x: e.velocity.x, y: 0 });
-          }
-          if (hasProjectile(e)) {
-            return onProjectileCollision();
-          }
+        if (rectRectCollision(entityToRect(collidable), getHitbox(e))) {
+          e.position = subVector(e.position, { x: e.velocity.x, y: 0 });
           break;
         }
       }
 
       e.position = addVector(e.position, { x: 0, y: e.velocity.y });
       for (const collidable of collidables) {
-        if (rectRectCollision(entityToRect(collidable), getHitbox())) {
-          if (hasPlayer(e)) {
-            e.position = subVector(e.position, { x: 0, y: e.velocity.y });
-          }
-          if (hasProjectile(e)) {
-            return onProjectileCollision();
-          }
-          break;
+        if (rectRectCollision(entityToRect(collidable), getHitbox(e))) {
+          e.position = subVector(e.position, { x: 0, y: e.velocity.y });
         }
       }
+    };
+
+    entities.forEach(e => {
+      if (hasImmoveable(e)) {
+        return;
+      }
+
+      handleSnapback(e);
+      handlePlayerMovement(e);
+      handleProjectileMovement(e);
     });
   }
 });

--- a/src/systems/ProjectileSystem.ts
+++ b/src/systems/ProjectileSystem.ts
@@ -1,0 +1,76 @@
+import type { ECSSystem } from '@/ecs/ECSSystem';
+import {
+  AnimatableBrand,
+  type Animatable,
+  AnimationState
+} from '@/entity/components/Animatable';
+import { deleteComponent } from '@/entity/components/Delete';
+import { EnemyBrand, type Enemy } from '@/entity/components/Enemy';
+import { hasPlayer } from '@/entity/components/Player';
+import { PositionBrand, type Position } from '@/entity/components/Position';
+import {
+  ProjectileBrand,
+  type Projectile
+} from '@/entity/components/Projectile';
+import { SizeBrand, type Size } from '@/entity/components/Size';
+import {
+  StateAwareBrand,
+  type StateAware
+} from '@/entity/components/StateAware';
+import { getAnimationState } from '@/renderer/AnimationManager';
+import {
+  HitBoxId,
+  getAnimationDuration,
+  getSpriteHitbox
+} from '@/renderer/renderableUtils';
+import {
+  ProjectileState,
+  ProjectileStateTransitions
+} from '@/stateMachines/projectile';
+import { resolveStateMachine } from '@/stateMachines/stateMachineManager';
+import { spriteCollision } from '@/utils/collisions';
+import { dealDamage, removeProjectile } from '@/utils/ecsUtils';
+import { clamp } from '@/utils/math';
+
+export const ProjectileSystem: () => ECSSystem<
+  [Projectile, Position, Size, Animatable, StateAware]
+> = () => ({
+  target: [
+    ProjectileBrand,
+    PositionBrand,
+    SizeBrand,
+    AnimatableBrand,
+    StateAwareBrand
+  ],
+  run: (ecs, props, entities) => {
+    entities.forEach(e => {
+      const machine = resolveStateMachine(e.entity_id);
+      if (machine.getSnapshot().value === ProjectileState.DEAD) return;
+
+      ecs.getEntity(e.projectile.firedBy).match(
+        owner => {
+          if (hasPlayer(owner)) {
+            const enemies = ecs.entitiesByComponent<
+              [Enemy, Position, Animatable, Size]
+            >([EnemyBrand, PositionBrand, AnimatableBrand, SizeBrand]);
+
+            enemies.forEach(enemy => {
+              if (!spriteCollision(e, enemy)) return;
+              dealDamage({
+                to: enemy,
+                amount: e.projectile.stats.current.power,
+                ecs
+              });
+
+              removeProjectile(e, ecs);
+            });
+          }
+        },
+        () => {
+          console.warn('could not find owner of entity', e.entity_id);
+          ecs.addComponent(e, deleteComponent);
+        }
+      );
+    });
+  }
+});

--- a/src/utils/ecsUtils.ts
+++ b/src/utils/ecsUtils.ts
@@ -1,0 +1,80 @@
+import {
+  type EnemyStats,
+  type Enemy,
+  hasEnemy,
+  EnemyType
+} from '@/entity/components/Enemy';
+import {
+  type PlayerStats,
+  type Player,
+  hasPlayer
+} from '@/entity/components/Player';
+import {
+  AnimationState,
+  type Animatable
+} from '@/entity/components/Animatable';
+import type { Stats } from './types';
+import { clamp } from './math';
+import type { ECSEntity } from '@/ecs/ECSEntity';
+import {
+  hasProjectile,
+  type Projectile,
+  type ProjectileStats
+} from '@/entity/components/Projectile';
+import type { ECSWorld } from '@/ecs/ECSWorld';
+import { deleteComponent } from '@/entity/components/Delete';
+import { resolveStateMachine } from '@/stateMachines/stateMachineManager';
+import { ProjectileStateTransitions } from '@/stateMachines/projectile';
+import { getAnimationDuration } from '@/renderer/renderableUtils';
+import { TrapStateTransitions } from '@/stateMachines/trap';
+import { PlayerStateTransitions } from '@/stateMachines/player';
+
+export const getStats = <T extends PlayerStats | ProjectileStats | EnemyStats>(
+  entity: ECSEntity & (Player | Enemy | Projectile)
+) => {
+  if (hasPlayer(entity)) return entity.player.stats as Stats<T>;
+  if (hasEnemy(entity)) return entity.enemy.stats as Stats<T>;
+  if (hasProjectile(entity)) return entity.projectile.stats as Stats<T>;
+
+  throw new Error('Trying to get stats from unelligible entity');
+};
+
+export const dealDamage = ({
+  to,
+  amount,
+  ecs
+}: {
+  to: ECSEntity & (Player | Enemy);
+  amount: number;
+  ecs: ECSWorld;
+}) => {
+  const stats = getStats<PlayerStats | EnemyStats>(to);
+
+  stats.current.health = clamp(
+    stats.current.health - amount,
+    0,
+    stats.base.health
+  );
+  if (stats.current.health <= 0) {
+    ecs.addComponent(to, deleteComponent);
+  } else {
+    const machine = resolveStateMachine(to.entity_id);
+    if (hasPlayer(to)) {
+      machine.send(PlayerStateTransitions.TAKE_DAMAGE);
+    }
+    if (hasEnemy(to) && to.enemy.type === EnemyType.TRAP) {
+      machine.send(TrapStateTransitions.TAKE_DAMAGE);
+    }
+  }
+};
+
+export const removeProjectile = (
+  e: ECSEntity & Animatable & Projectile,
+  ecs: ECSWorld
+) => {
+  const machine = resolveStateMachine(e.entity_id);
+  machine.send(ProjectileStateTransitions.DIE);
+  setTimeout(() => {
+    ecs.addComponent(e.entity_id, deleteComponent);
+  }, getAnimationDuration(e.animatable.spriteName, AnimationState.DEAD));
+};


### PR DESCRIPTION
This PR handle the projectiles being able to damage the traps.
A few utility methods have been created to avoid duplicated code in the ECS systems.
codex entries have been changed into functions to produce a new stats object for every entity

todo:
- death animation on the trap
- handling enemy projectiles hitting the player, as we don't have enemy projectiles yet